### PR TITLE
Stop Node detection after the first usable candidate

### DIFF
--- a/src/DshLauncher/Services/NodeRuntimeDetector.cs
+++ b/src/DshLauncher/Services/NodeRuntimeDetector.cs
@@ -26,7 +26,6 @@ public sealed class NodeRuntimeDetector
             }
         }
 
-        var available = new List<(string Path, string Version)>();
         foreach (var candidate in GetCandidates())
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -39,16 +38,8 @@ public sealed class NodeRuntimeDetector
             var version = await ReadVersionAsync(candidate, cancellationToken);
             if (version is not null)
             {
-                available.Add((candidate, version));
+                return new NodeRuntimeInfo(true, candidate, version, null);
             }
-        }
-
-        var best = available
-            .OrderByDescending(static item => Version.TryParse(item.Version, out var parsed) ? parsed : new Version(0, 0))
-            .FirstOrDefault();
-        if (best.Path is not null)
-        {
-            return new NodeRuntimeInfo(true, best.Path, best.Version, null);
         }
 
         return NodeRuntimeInfo.Missing("PATH、Windows 常见安装目录和 DeepSeek Desktop 中都没有可用的 node.exe。");


### PR DESCRIPTION
### Motivation
- Prevent a startup-time PATH-hijack by avoiding execution of every discovered `node.exe` candidate to compare reported versions, which allowed lower-priority malicious executables to run during launcher load.

### Description
- Update `DetectAsync` in `src/DshLauncher/Services/NodeRuntimeDetector.cs` to return immediately when the first candidate yields a usable `--version` response instead of accumulating and sorting all candidates.
- Preserve the existing `preferredPath` check so an explicit configured runtime is still preferred and validated first.
- Remove the accumulation/sorting logic that required executing all discovered candidates, thus avoiding launching lower-priority executables.

### Testing
- Ran a targeted Python assertion that inspects `src/DshLauncher/Services/NodeRuntimeDetector.cs` and verifies the candidate loop returns at the first usable candidate and that accumulation/sorting code is removed, and the assertion passed.
- Ran `git diff --check` and `git status` to verify repository checks and working-tree state, and both checks passed in this environment.
- Attempted to run .NET/C# self-tests with `dotnet --info` but the .NET SDK is not installed in this environment so full project tests could not be executed (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a829ea00d74832cb15703643feb24b1)