### PR TITLE
ci: notify Codex Review through ntfy on Windows

### DIFF
--- a/.github/workflows/codex-review-ntfy.yml
+++ b/.github/workflows/codex-review-ntfy.yml
@@ -1,0 +1,109 @@
+name: Notify Codex Review via ntfy
+
+on:
+  pull_request_review:
+    types: [submitted]
+  check_run:
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      title:
+        description: Notification title for a manual test
+        required: false
+        default: DSH Launcher · ntfy test
+      message:
+        description: Notification body for a manual test
+        required: false
+        default: GitHub Actions can reach ntfy.
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  notify:
+    name: Notify Windows via ntfy
+    if: >-
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event_name == 'pull_request_review' &&
+       github.event.review.state == 'approved' &&
+       vars.CODEX_REVIEW_ACTOR != '' &&
+       github.event.review.user.login == vars.CODEX_REVIEW_ACTOR) ||
+      (github.event_name == 'check_run' &&
+       github.event.action == 'completed' &&
+       github.event.check_run.conclusion == 'success' &&
+       vars.CODEX_REVIEW_CHECK_NAME != '' &&
+       github.event.check_run.name == vars.CODEX_REVIEW_CHECK_NAME &&
+       github.event.check_run.pull_requests[0].number != '')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish ntfy notification
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REVIEW_ACTOR: ${{ github.event.review.user.login }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.check_run.pull_requests[0].number }}
+          PR_URL: ${{ github.event.pull_request.html_url || github.event.check_run.pull_requests[0].html_url }}
+          CHECK_NAME: ${{ github.event.check_run.name }}
+          NTFY_SERVER: ${{ vars.NTFY_SERVER || 'https://ntfy.sh' }}
+          NTFY_TOPIC: ${{ secrets.NTFY_TOPIC }}
+          NTFY_TOKEN: ${{ secrets.NTFY_TOKEN }}
+          TEST_TITLE: ${{ inputs.title }}
+          TEST_MESSAGE: ${{ inputs.message }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ -z "$NTFY_TOPIC" ]]; then
+            echo "::error::Repository secret NTFY_TOPIC is not configured."
+            exit 1
+          fi
+
+          if [[ "$NTFY_TOPIC" == */* || "$NTFY_TOPIC" == *\?* || "$NTFY_TOPIC" == *#* ]]; then
+            echo "::error::NTFY_TOPIC must be a single topic name, not a URL or path."
+            exit 1
+          fi
+
+          if [[ "$NTFY_SERVER" != https://* ]]; then
+            echo "::error::NTFY_SERVER must use HTTPS."
+            exit 1
+          fi
+
+          ntfy_url="${NTFY_SERVER%/}/${NTFY_TOPIC}"
+          click_url="${PR_URL:-https://github.com/${REPOSITORY}/actions/runs/${RUN_ID}}"
+
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            title="${TEST_TITLE:-DSH Launcher · ntfy test}"
+            message="${TEST_MESSAGE:-GitHub Actions can reach ntfy.}"
+          elif [[ "$EVENT_NAME" == "pull_request_review" ]]; then
+            title="DSH Launcher · Codex Review passed"
+            printf -v message '%s (#%s)\nCodex Review by @%s was approved.' \
+              "$PR_TITLE" "$PR_NUMBER" "$REVIEW_ACTOR"
+          else
+            title="DSH Launcher · Codex check passed"
+            printf -v message 'Check "%s" passed for PR #%s.' \
+              "$CHECK_NAME" "$PR_NUMBER"
+          fi
+
+          headers=(
+            -H "Title: $title"
+            -H "Priority: high"
+            -H "Tags: github,codex,white_check_mark"
+            -H "Click: $click_url"
+          )
+
+          if [[ -n "$NTFY_TOKEN" ]]; then
+            headers+=(-H "Authorization: Bearer $NTFY_TOKEN")
+          fi
+
+          curl \
+            --fail \
+            --silent \
+            --show-error \
+            --retry 3 \
+            --retry-delay 2 \
+            "${headers[@]}" \
+            --data-raw "$message" \
+            "$ntfy_url"

--- a/docs/github-codex-review-ntfy.md
+++ b/docs/github-codex-review-ntfy.md
@@ -1,0 +1,61 @@
+# Codex Review → Windows ntfy 通知
+
+本仓库的 `.github/workflows/codex-review-ntfy.yml` 支持两种 Codex Review 结果来源：
+
+- Codex 以 GitHub Review 身份提交 `approved` review；需要配置 `CODEX_REVIEW_ACTOR`。
+- Codex 产生 GitHub Check Run；需要配置准确的 `CODEX_REVIEW_CHECK_NAME`，且结论必须为 `success`。
+
+没有配置对应的账号或检查名时，workflow 不会把普通人工批准当成 Codex 通过。
+
+## GitHub 配置
+
+在仓库 `Settings → Secrets and variables → Actions` 中配置：
+
+| 类型                 | 名称                      | 用途                                               |
+| -------------------- | ------------------------- | -------------------------------------------------- |
+| Secret               | `NTFY_TOPIC`              | ntfy topic 名称；不要提交到仓库                    |
+| Secret，可选         | `NTFY_TOKEN`              | 使用受保护 topic 或自建 ntfy 服务时的 Bearer token |
+| Variable，可选       | `NTFY_SERVER`             | ntfy 服务地址，默认 `https://ntfy.sh`              |
+| Variable，按事件需要 | `CODEX_REVIEW_ACTOR`      | Codex Review 机器人的 GitHub 登录名                |
+| Variable，按事件需要 | `CODEX_REVIEW_CHECK_NAME` | Codex Check Run 的准确名称                         |
+
+`NTFY_TOPIC` 应使用不可猜测的随机名称。公开 ntfy 服务的 topic 名称本身就是订阅入口，不要使用 `dsh-launcher` 这类简单名称；如果服务支持访问控制，建议同时配置 `NTFY_TOKEN`。
+
+Windows PowerShell 中可通过 GitHub CLI 配置变量。GitHub 网络操作使用本机安全包装脚本：
+
+```powershell
+$ghSafe = "C:\Users\121103qwq\.codex\scripts\github-safe.ps1"
+$repo = "121103qwq/DSH-Launcher"
+
+& $ghSafe variable set CODEX_REVIEW_CHECK_NAME --repo $repo --body "Codex Review"
+& $ghSafe variable set NTFY_SERVER --repo $repo --body "https://ntfy.sh"
+& $ghSafe secret set NTFY_TOPIC --repo $repo
+```
+
+最后一条命令会隐藏输入内容；输入随机 topic 后按 Enter。若 Codex 使用 Review 身份而不是 Check Run，再配置实际登录名：
+
+```powershell
+& $ghSafe variable set CODEX_REVIEW_ACTOR --repo $repo --body "实际的 Codex GitHub 登录名"
+```
+
+当前仓库尚未出现 Codex Check Run 或 Review，因此不能凭空填入最后两个值。第一次 Codex 审查完成后，从 PR 的 Checks 或 Reviews 页面复制准确名称/登录名再配置。
+
+## Windows 桌面接收
+
+ntfy 官方目前推荐 Windows 使用 Web/PWA，而不是假设存在一个官方原生桌面客户端：
+
+1. 在 Edge 打开 `https://ntfy.sh/app`。
+2. 订阅与 GitHub Secret 完全相同的 topic。
+3. 开启后台通知；需要常驻桌面入口时，把 ntfy 安装为 Edge PWA。
+4. 在 Windows 通知设置中允许 Edge/ntfy 通知。
+
+## 测试
+
+workflow 文件进入默认分支且 Secrets/Variables 配置完成后，可手动发送测试通知：
+
+```powershell
+& $ghSafe workflow run codex-review-ntfy.yml --repo $repo
+& $ghSafe run list --repo $repo --workflow codex-review-ntfy.yml --limit 3
+```
+
+实际 Codex Review 通过时，workflow 会把 PR 链接放入 ntfy 的点击动作。此实现只负责通知，不会自动 Merge，也不会修改分支保护规则。


### PR DESCRIPTION
Adds a guarded GitHub Actions workflow for Codex approved reviews or matching successful check runs, publishing high-priority ntfy notifications with PR links. Adds setup documentation for NTFY_TOPIC, optional NTFY_TOKEN/NTFY_SERVER, and Codex actor/check-name variables. Local validation: Prettier, Bash syntax, and git diff --check passed. This PR does not modify application source or merge settings.